### PR TITLE
Fix visibility detection on svg elements

### DIFF
--- a/src/utils/element.ts
+++ b/src/utils/element.ts
@@ -9,8 +9,8 @@ export const getTabIndex = (node: Element): number => {
 /** Returns whether an element is visible in the context of focusability. */
 export const isVisible = (node: Element): boolean =>
   !!(
-    (node as HTMLElement).offsetWidth &&
-    (node as HTMLElement).offsetHeight &&
+    (node as HTMLElement).clientWidth &&
+    (node as HTMLElement).clientHeight &&
     node.getClientRects().length &&
     getComputedStyle(node).visibility !== 'hidden'
   );


### PR DESCRIPTION
# About

Seems like `svg` elements aren't considered visible because an `offsetWidth` value is expected


https://user-images.githubusercontent.com/10779424/161786022-de86bd61-ccb9-45e5-975a-34a0e1bf24a1.mp4

This is a quick fix, although I suspect `getBoundingClientRect` is going to be the best way to check absolute dimensions of an element.