### PR TITLE
Default focus

### DIFF
--- a/src/utils/focus.ts
+++ b/src/utils/focus.ts
@@ -62,7 +62,7 @@ export const getFocusTargets = (node: Element): HTMLElement[] => {
 /** Returns the first focus target that should be focused automatically. */
 export const getFirstFocusTarget = (node: HTMLElement): HTMLElement | null => {
   const targets = getFocusTargets(node);
-  return targets.find(x => x.matches('[autofocus]')) || targets[0] || null;
+  return targets.find(x => x.matches('[autofocus]')) || node;
 };
 
 /** Returns the next (optionally in reverse) focus target given a target node. */


### PR DESCRIPTION
# About

Change to focus on the autofocus element, or if not present, then the modal/dialog/etc itself

Prevents awkward forced focus states on elements when using mouse navigation.

Not tested