### PR TITLE
fix types

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "include": ["./src"],
   "compilerOptions": {
     "types": ["react", "cypress", "cypress-real-events"],
     "baseUrl": "./",


### PR DESCRIPTION
Types were picked up from `baseUrl: ./` which meant we were including the whole repo as types. Instead this now scopes the types to `src`